### PR TITLE
Add support for .netcoreapp and net4x TFMs to LibVLC.Mac

### DIFF
--- a/VideoLAN.LibVLC.Mac.nuspec
+++ b/VideoLAN.LibVLC.Mac.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>VideoLAN.LibVLC.Mac</id>
     <title>VideoLAN.LibVLC.Mac</title>
-    <version>3.1.2-alpha</version>
+    <version>3.1.2</version>
     <authors>VideoLAN</authors>
     <owners>VideoLAN</owners>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
@@ -16,6 +16,6 @@
   </metadata>
   <files>
     <file src="build\VideoLAN.LibVLC.Mac.targets" target="build\VideoLAN.LibVLC.Mac.targets"/>
-    <file src="build\osx-x64\VLCKit.framework\**" target="build\osx-x64\VLCKit.framework"/>
+    <file src="build\osx-x64\libvlc.dylib" target="build\osx-x64\libvlc.dylib"/>
   </files>
 </package>

--- a/build/VideoLAN.LibVLC.Mac.targets
+++ b/build/VideoLAN.LibVLC.Mac.targets
@@ -1,28 +1,29 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <ItemGroup>
+<!--   <ItemGroup>
     <NativeReference Include="$(MSBuildThisFileDirectory)osx-x64\VLCKit.framework">
       <Kind>Framework</Kind>
       <SmartLink>False</SmartLink>
     </NativeReference>
-  </ItemGroup>
+  </ItemGroup> -->
 
-  <PropertyGroup>
-    <VlcMacX64TargetDir Condition=" '$(VlcMacX64TargetDir)' == '' ">libvlc\osx-x64</VlcMacX64TargetDir>
-  </PropertyGroup>
-
-  <ItemGroup>
-      <VlcMacX64IncludeFile Condition="'@(VlcMacX64IncludeFile)'==''" Include="VLCKit.framework\libvlc.dylib" />
-  </ItemGroup>
-
-<Target Name="CopyLibVLCMac" BeforeTargets="BeforeBuild" Condition=" '$(TargetFramework)' == 'net' ">
-  <ItemGroup>
-    <VlcMacX64IncludeFileFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\osx-x64\%(VlcMacX64IncludeFile.Identity)))" />
-
-    <Content Include="@(VlcMacX64IncludeFileFullPath)">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      <Link>$(VlcMacX64TargetDir)\$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\osx-x64\, %(FullPath)))</Link>
-    </Content>
-
-  </ItemGroup>
+<!-- Works, but conditional targetframeworks does not -->
+  <Target Name="CopyMacOutput" BeforeTargets="BeforeBuild">
+    <ItemGroup>
+      <Content Include="$(MSBuildThisFileDirectory)osx-x64\VLCKit.framework\libvlc.dylib">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </Content>
+    </ItemGroup>
   </Target>
+
+<!-- Does not get called (with or without condition). Looks like stuff needs to be in a Target, but Choose/When does not work with Targets -->
+<!-- 
+  <Choose>
+    <When Condition=" '$(TargetFramework)' == 'net47' ">
+      <ItemGroup>
+        <Content Include="$(MSBuildThisFileDirectory)osx-x64\VLCKit.framework\libvlc.dylib">
+          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+      </ItemGroup>
+    </When>
+  </Choose> -->
 </Project>

--- a/build/VideoLAN.LibVLC.Mac.targets
+++ b/build/VideoLAN.LibVLC.Mac.targets
@@ -1,9 +1,19 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!-- net4.x and netcoreapp targets -->
+    <ItemGroup Condition="$(TargetFramework.StartsWith('net'))">
+        <Content Include="$(MSBuildThisFileDirectory)osx-x64\libvlc.dylib">
+            <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        </Content>
+    </ItemGroup>
+
+    <!-- xamarin.mac target -->
     <PropertyGroup>
         <CreateAppBundleDependsOn>$(CreateAppBundleDependsOn);CopyLibvlcDylib</CreateAppBundleDependsOn>
     </PropertyGroup>
-	<Target Name="CopyLibvlcDylib" Inputs="$(MSBuildThisFileDirectory)osx-x64\libvlc.dylib" Outputs="$(AppBundleDir)/Contents/MonoBundle/libvlc.dylib">
-		<Message Text="Copying libvlc.dylib to appbundle..." />
-	    <Copy SourceFiles="$(MSBuildThisFileDirectory)osx-x64\libvlc.dylib" DestinationFiles="$(AppBundleDir)/Contents/MonoBundle/libvlc.dylib" />
+	<Target Name="CopyLibvlcDylib" 
+        Inputs="$(MSBuildThisFileDirectory)osx-x64\libvlc.dylib"
+        Outputs="$(AppBundleDir)/Contents/MonoBundle/libvlc.dylib">
+            <Message Text="Copying libvlc.dylib to appbundle..." />
+            <Copy SourceFiles="$(MSBuildThisFileDirectory)osx-x64\libvlc.dylib" DestinationFiles="$(AppBundleDir)/Contents/MonoBundle/libvlc.dylib" />
     </Target>
 </Project>

--- a/build/VideoLAN.LibVLC.Mac.targets
+++ b/build/VideoLAN.LibVLC.Mac.targets
@@ -5,4 +5,24 @@
       <SmartLink>False</SmartLink>
     </NativeReference>
   </ItemGroup>
+
+  <PropertyGroup>
+    <VlcMacX64TargetDir Condition=" '$(VlcMacX64TargetDir)' == '' ">libvlc\osx-x64</VlcMacX64TargetDir>
+  </PropertyGroup>
+
+  <ItemGroup>
+      <VlcMacX64IncludeFile Condition="'@(VlcMacX64IncludeFile)'==''" Include="VLCKit.framework\libvlc.dylib" />
+  </ItemGroup>
+
+<Target Name="CopyLibVLCMac" BeforeTargets="BeforeBuild" Condition=" '$(TargetFramework)' == 'net' ">
+  <ItemGroup>
+    <VlcMacX64IncludeFileFullPath Include="$([MSBuild]::Unescape($(MSBuildThisFileDirectory)..\build\osx-x64\%(VlcMacX64IncludeFile.Identity)))" />
+
+    <Content Include="@(VlcMacX64IncludeFileFullPath)">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <Link>$(VlcMacX64TargetDir)\$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\osx-x64\, %(FullPath)))</Link>
+    </Content>
+
+  </ItemGroup>
+  </Target>
 </Project>

--- a/build/VideoLAN.LibVLC.Mac.targets
+++ b/build/VideoLAN.LibVLC.Mac.targets
@@ -1,29 +1,9 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-<!--   <ItemGroup>
-    <NativeReference Include="$(MSBuildThisFileDirectory)osx-x64\VLCKit.framework">
-      <Kind>Framework</Kind>
-      <SmartLink>False</SmartLink>
-    </NativeReference>
-  </ItemGroup> -->
-
-<!-- Works, but conditional targetframeworks does not -->
-  <Target Name="CopyMacOutput" BeforeTargets="BeforeBuild">
-    <ItemGroup>
-      <Content Include="$(MSBuildThisFileDirectory)osx-x64\VLCKit.framework\libvlc.dylib">
-        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-      </Content>
-    </ItemGroup>
-  </Target>
-
-<!-- Does not get called (with or without condition). Looks like stuff needs to be in a Target, but Choose/When does not work with Targets -->
-<!-- 
-  <Choose>
-    <When Condition=" '$(TargetFramework)' == 'net47' ">
-      <ItemGroup>
-        <Content Include="$(MSBuildThisFileDirectory)osx-x64\VLCKit.framework\libvlc.dylib">
-          <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-        </Content>
-      </ItemGroup>
-    </When>
-  </Choose> -->
+    <PropertyGroup>
+        <CreateAppBundleDependsOn>$(CreateAppBundleDependsOn);CopyLibvlcDylib</CreateAppBundleDependsOn>
+    </PropertyGroup>
+	<Target Name="CopyLibvlcDylib" Inputs="$(MSBuildThisFileDirectory)osx-x64\libvlc.dylib" Outputs="$(AppBundleDir)/Contents/MonoBundle/libvlc.dylib">
+		<Message Text="Copying libvlc.dylib to appbundle..." />
+	    <Copy SourceFiles="$(MSBuildThisFileDirectory)osx-x64\libvlc.dylib" DestinationFiles="$(AppBundleDir)/Contents/MonoBundle/libvlc.dylib" />
+    </Target>
 </Project>


### PR DESCRIPTION
To support net and netcoreapp targets, the mac libvlc nuget targets file needs modification. It currently just support Xamarin.Mac targets.

I have a tried a few things but cannot get it to work (not copied to output) and the lack of diagnostics/logs is very annoying.

Xamarin.Mac knows how to reference the .framework with its specific `NativeReference` attribute.

With the other targets that don't understand `NativeReference`, we need to copy to the output (and rename) the dylib inside `VLCKit.framework` (i.e. `VLCKit.Framework/VLCKit` -> `libvlc.dylib`) to make P/Invoke work. 
Will rename it for both before packaging if it doesn't break Xamarin.Mac.

Deciding to copy/link the dylib depends on the TFM, and targets/conditions DO NOT play nice on macOS (i.e. fails silently....)

Relevant links:
https://stackoverflow.com/questions/46796065/conditional-reference-in-visual-studio-community-2017
https://stackoverflow.com/questions/45215736/error-msb4067-the-element-when-beneath-element-choose-is-unrecognized
