### PR TITLE
[Windows] Added CopyToPublishDirectory for libvlc dlls

### DIFF
--- a/build/VideoLAN.LibVLC.UWP.targets
+++ b/build/VideoLAN.LibVLC.UWP.targets
@@ -39,6 +39,7 @@
       <Content Include="@(VlcUWPX64IncludeFilesFullPath)" Exclude="@(VlcUWPX64ExcludeFilesFullPath)">
         <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\win10-x64\, %(FullPath)))</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </Content>
     </ItemGroup>
 
@@ -52,6 +53,7 @@
       <Content Include="@(VlcUWPX86IncludeFilesFullPath)" Exclude="@(VlcUWPX86ExcludeFilesFullPath)">
         <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\win10-x86\, %(FullPath)))</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </Content>
     </ItemGroup>
 
@@ -65,6 +67,7 @@
       <Content Include="@(VlcUWPARMIncludeFilesFullPath)" Exclude="@(VlcUWPARMExcludeFilesFullPath)">
         <Link>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\win10-arm\, %(FullPath)))</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </Content>
     </ItemGroup>
   </Target>

--- a/build/VideoLAN.LibVLC.Windows.targets
+++ b/build/VideoLAN.LibVLC.Windows.targets
@@ -32,6 +32,7 @@
       <Content Include="@(VlcWindowsX64IncludeFilesFullPath)" Exclude="@(VlcWindowsX64ExcludeFilesFullPath)">
         <Link>$(VlcWindowsX64TargetDir)\$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\x64\, %(FullPath)))</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </Content>
     </ItemGroup>
 
@@ -45,6 +46,7 @@
       <Content Include="@(VlcWindowsX86IncludeFilesFullPath)" Exclude="@(VlcWindowsX86ExcludeFilesFullPath)">
         <Link>$(VlcWindowsX86TargetDir)\$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory)..\build\x86\, %(FullPath)))</Link>
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+        <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </Content>
     </ItemGroup>
   </Target>


### PR DESCRIPTION
Untested attempt to fix https://code.videolan.org/videolan/LibVLCSharp/-/issues/454

This change is likely necessary anyway when publishing with `dotnet publish`